### PR TITLE
Support role updates in message edit endpoint

### DIFF
--- a/lima_gui/routers/chat.py
+++ b/lima_gui/routers/chat.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Request, UploadFile, File, HTTPException, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
-from lima_gui.models import Chat, Message, Tool, ToolCall, get_chat_db
+from lima_gui.models import Chat, Message, Tool, ToolCall, Tag, get_chat_db
+from lima_gui.models.chat import RoleEnum
 import json
 from ..services.chat import get_chat as _get_chat
 from ..services.chat import add_message as _add_message
@@ -46,10 +47,57 @@ async def get_chat(id: int, db: Session = Depends(get_chat_db)):
 async def update_chat(id: int, request: Request, db: Session = Depends(get_chat_db)):
     data = await request.json()
     chat = db.query(Chat).get(id)
-    chat.name = data["name"]
-    chat.tags = data["tags"]
+
+    if not chat:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found")
+
+    name = data.get("name")
+    if name is not None:
+        chat.name = name
+
+    language = data.get("language")
+    if language is not None:
+        chat.language = language
+
+    if "tags" in data:
+        raw_tags = data.get("tags") or []
+
+        if not isinstance(raw_tags, list):
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Tags must be provided as a list")
+
+        existing_tags = {}
+        if raw_tags:
+            db_tags = db.query(Tag).filter(Tag.name.in_(raw_tags)).all()
+            existing_tags = {tag.name: tag for tag in db_tags}
+
+        new_tag_objects = []
+        seen = set()
+        for tag_name in raw_tags:
+            if not isinstance(tag_name, str):
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Each tag must be a string")
+
+            tag_name = tag_name.strip()
+            if not tag_name or tag_name in seen:
+                continue
+            seen.add(tag_name)
+
+            tag_obj = existing_tags.get(tag_name)
+            if not tag_obj:
+                tag_obj = Tag(name=tag_name)
+                db.add(tag_obj)
+                existing_tags[tag_name] = tag_obj
+
+            new_tag_objects.append(tag_obj)
+
+        chat.tags = new_tag_objects
+
     db.commit()
-    return {"status": "success", "message": "Chat updated"}
+
+    updated_chat = _get_chat(id, db)
+    if updated_chat is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found")
+
+    return updated_chat
 
 
 @chat_router.post("/{id}/tools", response_model=ToolSchema)
@@ -106,19 +154,52 @@ async def add_message(id: int, db: Session = Depends(get_chat_db)):
     return msg
 
 
-@chat_router.put("/{id}/message/{message_id}")
+@chat_router.put("/{id}/message/{message_id}", response_model=MessageSchema)
 async def update_message(id: int, message_id: int, request: Request, db: Session = Depends(get_chat_db)):
     data = await request.json()
     message = db.query(Message).filter(Message.id == message_id, Message.chat_id == id).first()
-    message.content = data["content"]
+
+    if not message:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Message not found")
+
+    updated = False
+
+    if "content" in data:
+        message.content = data["content"]
+        updated = True
+
+    if "role" in data:
+        role_value = data["role"]
+        if role_value is None:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Role cannot be null")
+
+        try:
+            role_enum = RoleEnum(role_value)
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid role value")
+
+        message.role = role_enum
+        updated = True
+
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No supported fields provided for update",
+        )
+
     db.commit()
-    return {"status": "success", "message": "Message updated"}
+    db.refresh(message)
+
+    return MessageSchema.from_orm(message)
 
 
 @chat_router.delete("/{chat_id}/message/{message_id}")
-async def delete_message(id: int, message_id: int, db: Session = Depends(get_chat_db)):
-    message = db.query(Message).filter(Message.id == message_id, Message.chat_id == id).first()
-    
+async def delete_message(chat_id: int, message_id: int, db: Session = Depends(get_chat_db)):
+    message = db.query(Message).filter(
+        Message.id == message_id,
+        Message.chat_id == chat_id,
+    ).first()
+
     if not message:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Message not found")
 
@@ -126,8 +207,13 @@ async def delete_message(id: int, message_id: int, db: Session = Depends(get_cha
     db.commit()
 
     # Reorder remaining messages
-    remaining_messages = db.query(Message).filter(Message.chat_id == id).order_by(Message.position).all()
-    
+    remaining_messages = (
+        db.query(Message)
+        .filter(Message.chat_id == chat_id)
+        .order_by(Message.position)
+        .all()
+    )
+
     for index, msg in enumerate(remaining_messages):
         msg.position = index + 1  # Reassign position starting from 1
 

--- a/lima_gui/test_chat_delete_message.py
+++ b/lima_gui/test_chat_delete_message.py
@@ -1,0 +1,75 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from lima_gui.main import app
+from lima_gui.models.chat import ChatBase, Chat, Message, RoleEnum
+from lima_gui.models.db import get_chat_db
+
+
+@pytest.fixture()
+def client_and_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ChatBase.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+
+    def override_get_chat_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_chat_db] = override_get_chat_db
+
+    with TestClient(app) as test_client:
+        yield test_client, TestingSessionLocal
+
+    app.dependency_overrides.pop(get_chat_db, None)
+
+
+def create_chat_with_messages(session_factory):
+    with session_factory() as session:
+        chat = Chat(name="Chat", language="en")
+        session.add(chat)
+        session.flush()
+
+        message_ids = []
+        for index, content in enumerate(["first", "second", "third"], start=1):
+            message = Message(
+                chat=chat,
+                role=RoleEnum.user,
+                content=content,
+                position=index,
+            )
+            session.add(message)
+            session.flush()
+            message_ids.append(message.id)
+
+        session.commit()
+        return chat.id, message_ids
+
+
+def test_delete_message_reorders_remaining_positions(client_and_session):
+    client, session_factory = client_and_session
+    chat_id, message_ids = create_chat_with_messages(session_factory)
+
+    response = client.delete(f"/chat/{chat_id}/message/{message_ids[1]}")
+
+    assert response.status_code == 200
+
+    with session_factory() as session:
+        remaining = (
+            session.query(Message)
+            .filter(Message.chat_id == chat_id)
+            .order_by(Message.position)
+            .all()
+        )
+        assert [message.id for message in remaining] == [message_ids[0], message_ids[2]]
+        assert [message.position for message in remaining] == [1, 2]

--- a/lima_gui/test_chat_metadata.py
+++ b/lima_gui/test_chat_metadata.py
@@ -1,0 +1,115 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from lima_gui.main import app
+from lima_gui.models.chat import ChatBase, Chat, Message, Tag, Tool, RoleEnum
+from lima_gui.models.db import get_chat_db
+
+
+@pytest.fixture()
+def client_and_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ChatBase.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+
+    def override_get_chat_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_chat_db] = override_get_chat_db
+
+    with TestClient(app) as test_client:
+        yield test_client, TestingSessionLocal
+
+    app.dependency_overrides.pop(get_chat_db, None)
+
+
+def seed_chat(session_factory):
+    with session_factory() as session:
+        tag_alpha = session.get(Tag, "alpha")
+        if not tag_alpha:
+            tag_alpha = Tag(name="alpha")
+            session.add(tag_alpha)
+        tool = Tool(
+            name="calculator",
+            description="Performs arithmetic",
+            parameters={"type": "object", "properties": {"a": {"type": "number"}}},
+        )
+        chat = Chat(name="Metadata", language="fr")
+        chat.tags.append(tag_alpha)
+        chat.tools.append(tool)
+        chat.messages.append(
+            Message(
+                role=RoleEnum.system,
+                content="bonjour monde",
+                position=1,
+            )
+        )
+        chat.messages.append(
+            Message(
+                role=RoleEnum.assistant,
+                content="salut",
+                position=2,
+            )
+        )
+        session.add(chat)
+        session.commit()
+        session.refresh(chat)
+        chat_id = chat.id
+
+    return chat_id
+
+
+def test_chat_details_include_metadata(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = seed_chat(session_factory)
+
+    response = client.get(f"/chat/{chat_id}")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["language"] == "fr"
+    assert payload["tags"] == ["alpha"]
+    assert payload["tools"] == [
+        {
+            "name": "calculator",
+            "description": "Performs arithmetic",
+            "parameters": {"type": "object", "properties": {"a": {"type": "number"}}},
+        }
+    ]
+    # Token calculation splits on whitespace, so the two messages yield three tokens total.
+    assert payload["tokens"] == 3
+    assert payload["n_msgs"] == 2
+
+
+def test_chat_list_contains_metadata(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = seed_chat(session_factory)
+
+    response = client.get("/chats")
+    assert response.status_code == 200
+
+    chat_list = response.json()
+    assert isinstance(chat_list, list)
+    chat_entry = next(item for item in chat_list if item["id"] == chat_id)
+    assert chat_entry["language"] == "fr"
+    assert chat_entry["tags"] == ["alpha"]
+    assert chat_entry["tokens"] == 3
+    assert chat_entry["message_count"] == 2
+    assert chat_entry["tools"] == [
+        {
+            "name": "calculator",
+            "description": "Performs arithmetic",
+            "parameters": {"type": "object", "properties": {"a": {"type": "number"}}},
+        }
+    ]

--- a/lima_gui/test_chat_update.py
+++ b/lima_gui/test_chat_update.py
@@ -1,0 +1,160 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from lima_gui.main import app
+from lima_gui.models.chat import ChatBase, Chat, Tag, Message, RoleEnum
+from lima_gui.models.db import get_chat_db
+
+
+@pytest.fixture()
+def client_and_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ChatBase.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+
+    def override_get_chat_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_chat_db] = override_get_chat_db
+
+    with TestClient(app) as test_client:
+        yield test_client, TestingSessionLocal
+
+    app.dependency_overrides.pop(get_chat_db, None)
+
+
+def create_chat(session_factory, *, name="Chat", language="en", tags=None):
+    with session_factory() as session:
+        tag_objects = []
+        if tags:
+            for tag_name in tags:
+                tag = session.get(Tag, tag_name)
+                if not tag:
+                    tag = Tag(name=tag_name)
+                    session.add(tag)
+                tag_objects.append(tag)
+
+        chat = Chat(name=name, language=language)
+        chat.tags = tag_objects
+        session.add(chat)
+        session.commit()
+        session.refresh(chat)
+        return chat.id
+
+
+def create_message(session_factory, chat_id, *, role=RoleEnum.user, content="", position=1):
+    with session_factory() as session:
+        chat = session.get(Chat, chat_id)
+        message = Message(chat=chat, role=role, content=content, position=position)
+        session.add(message)
+        session.commit()
+        session.refresh(message)
+        return message.id
+
+
+def test_update_chat_name_only(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = create_chat(session_factory, name="Original")
+
+    response = client.put(f"/chat/{chat_id}", json={"name": "Updated"})
+
+    assert response.status_code == 200
+
+    with session_factory() as session:
+        updated_chat = session.get(Chat, chat_id)
+        assert updated_chat.name == "Updated"
+
+
+def test_update_chat_language_only(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = create_chat(session_factory, language="en")
+
+    response = client.put(f"/chat/{chat_id}", json={"language": "fr"})
+
+    assert response.status_code == 200
+
+    with session_factory() as session:
+        updated_chat = session.get(Chat, chat_id)
+        assert updated_chat.language == "fr"
+
+
+def test_update_chat_tags_with_strings(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = create_chat(session_factory, tags=["initial"])
+
+    response = client.put(f"/chat/{chat_id}", json={"tags": ["alpha", "beta"]})
+
+    assert response.status_code == 200
+
+    with session_factory() as session:
+        updated_chat = session.get(Chat, chat_id)
+        assert sorted(tag.name for tag in updated_chat.tags) == ["alpha", "beta"]
+        all_tags = session.query(Tag).filter(Tag.name.in_(["alpha", "beta"])).all()
+        assert sorted(tag.name for tag in all_tags) == ["alpha", "beta"]
+
+
+def test_update_message_content_only(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = create_chat(session_factory)
+    message_id = create_message(session_factory, chat_id, content="Original")
+
+    response = client.put(
+        f"/chat/{chat_id}/message/{message_id}",
+        json={"content": "Updated content"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["content"] == "Updated content"
+    assert payload["role"] == RoleEnum.user.value
+
+    with session_factory() as session:
+        message = session.get(Message, message_id)
+        assert message.content == "Updated content"
+
+
+def test_update_message_role_only(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = create_chat(session_factory)
+    message_id = create_message(session_factory, chat_id, role=RoleEnum.user)
+
+    response = client.put(
+        f"/chat/{chat_id}/message/{message_id}",
+        json={"role": "assistant"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["role"] == "assistant"
+
+    with session_factory() as session:
+        message = session.get(Message, message_id)
+        assert message.role == RoleEnum.assistant
+
+
+def test_update_message_invalid_role(client_and_session):
+    client, session_factory = client_and_session
+    chat_id = create_chat(session_factory)
+    message_id = create_message(session_factory, chat_id)
+
+    response = client.put(
+        f"/chat/{chat_id}/message/{message_id}",
+        json={"role": "invalid"},
+    )
+
+    assert response.status_code == 422
+
+    with session_factory() as session:
+        message = session.get(Message, message_id)
+        assert message.role == RoleEnum.user


### PR DESCRIPTION
## Summary
- allow the message update route to edit either content or role and return the refreshed message payload
- validate provided roles against the RoleEnum so null or unknown values raise proper API errors
- extend chat update tests to cover message content edits, role changes, and invalid role rejections

## Testing
- pytest lima_gui/test_chat_update.py

------
https://chatgpt.com/codex/tasks/task_e_68e228cd36c88333842ff7f3d0178cf2